### PR TITLE
User/dgreenshields/byte array

### DIFF
--- a/Juriba.Platform/Juriba.Platform.psd1
+++ b/Juriba.Platform/Juriba.Platform.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Juriba.Platform.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.0.50.0'
+    ModuleVersion     = '0.0.51.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/Juriba.Platform/Public/New-JuribaImportApplication.ps1
+++ b/Juriba.Platform/Public/New-JuribaImportApplication.ps1
@@ -57,12 +57,12 @@ function New-JuribaImportApplication {
     
         try {
             if ($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier) -and (($JsonBody | ConvertFrom-Json).Length -eq 1)) {
-                $result = Invoke-RestMethod -Uri $uri -Method POST -Headers $headers -ContentType "application/json" -Body $jsonBody
+                $result = Invoke-RestMethod -Uri $uri -Method POST -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JSONBody)
                 return $result
             }
             elseif ($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier) -and (($JsonBody | ConvertFrom-Json).Length -gt 1)) {
                 <# Bulk operation request #>
-                $result = Invoke-RestMethod -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body $jsonBody
+                $result = Invoke-RestMethod -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JSONBody)
                 return $result
             }
         }

--- a/Juriba.Platform/Public/New-JuribaImportApplication.ps1
+++ b/Juriba.Platform/Public/New-JuribaImportApplication.ps1
@@ -57,12 +57,12 @@ function New-JuribaImportApplication {
     
         try {
             if ($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier) -and (($JsonBody | ConvertFrom-Json).Length -eq 1)) {
-                $result = Invoke-RestMethod -Uri $uri -Method POST -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JSONBody)
+                $result = Invoke-RestMethod -Uri $uri -Method POST -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JSONBody))
                 return $result
             }
             elseif ($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier) -and (($JsonBody | ConvertFrom-Json).Length -gt 1)) {
                 <# Bulk operation request #>
-                $result = Invoke-RestMethod -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JSONBody)
+                $result = Invoke-RestMethod -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JSONBody))
                 return $result
             }
         }

--- a/Juriba.Platform/Public/New-JuribaImportDepartment.ps1
+++ b/Juriba.Platform/Public/New-JuribaImportDepartment.ps1
@@ -57,12 +57,12 @@ function New-JuribaImportDepartment {
     
         try {
             if (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -eq 1)) {
-                $result = Invoke-RestMethod -Uri $uri -Method POST -Headers $headers -ContentType "application/json" -Body $jsonBody
+                $result = Invoke-RestMethod -Uri $uri -Method POST -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JSONBody)
                 return $result
             }
             elseif (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -gt 1)) {
                 <# Bulk operation request #>
-                $result = Invoke-RestMethod -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body $jsonBody
+                $result = Invoke-RestMethod -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JSONBody)
                 return $result
             }
         }

--- a/Juriba.Platform/Public/New-JuribaImportDepartment.ps1
+++ b/Juriba.Platform/Public/New-JuribaImportDepartment.ps1
@@ -57,12 +57,12 @@ function New-JuribaImportDepartment {
     
         try {
             if (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -eq 1)) {
-                $result = Invoke-RestMethod -Uri $uri -Method POST -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JSONBody)
+                $result = Invoke-RestMethod -Uri $uri -Method POST -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
                 return $result
             }
             elseif (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -gt 1)) {
                 <# Bulk operation request #>
-                $result = Invoke-RestMethod -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JSONBody)
+                $result = Invoke-RestMethod -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
                 return $result
             }
         }

--- a/Juriba.Platform/Public/New-JuribaImportDevice.ps1
+++ b/Juriba.Platform/Public/New-JuribaImportDevice.ps1
@@ -57,12 +57,12 @@ function New-JuribaImportDevice {
     
         try {
             if (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -eq 1)) {
-                $result = Invoke-RestMethod -Uri $uri -Method POST -Headers $headers -ContentType "application/json" -Body $jsonBody
+                $result = Invoke-RestMethod -Uri $uri -Method POST -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
                 return $result
             }
             elseif (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -gt 1)) {
                 <# Bulk operation request #>
-                $result = Invoke-RestMethod -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body $jsonBody
+                $result = Invoke-RestMethod -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
                 return $result
             }
         }

--- a/Juriba.Platform/Public/New-JuribaImportGroup.ps1
+++ b/Juriba.Platform/Public/New-JuribaImportGroup.ps1
@@ -56,12 +56,12 @@ function New-JuribaImportGroup {
     
         try {
             if (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -eq 1)) {
-                $result = Invoke-RestMethod -Uri $uri -Method POST -Headers $headers -ContentType "application/json" -Body $jsonBody
+                $result = Invoke-RestMethod -Uri $uri -Method POST -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JSONBody)
                 return $result
             }
             elseif (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -gt 1)) {
                 <# Bulk operation request #>
-                $result = Invoke-RestMethod -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body $jsonBody
+                $result = Invoke-RestMethod -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JSONBody)
                 return $result
             }
         }

--- a/Juriba.Platform/Public/New-JuribaImportGroup.ps1
+++ b/Juriba.Platform/Public/New-JuribaImportGroup.ps1
@@ -56,12 +56,12 @@ function New-JuribaImportGroup {
     
         try {
             if (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -eq 1)) {
-                $result = Invoke-RestMethod -Uri $uri -Method POST -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JSONBody)
+                $result = Invoke-RestMethod -Uri $uri -Method POST -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
                 return $result
             }
             elseif (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -gt 1)) {
                 <# Bulk operation request #>
-                $result = Invoke-RestMethod -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JSONBody)
+                $result = Invoke-RestMethod -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
                 return $result
             }
         }

--- a/Juriba.Platform/Public/New-JuribaImportLocation.ps1
+++ b/Juriba.Platform/Public/New-JuribaImportLocation.ps1
@@ -57,12 +57,12 @@ function New-JuribaImportLocation {
     
         try {
             if (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -eq 1)) {
-                $result = Invoke-RestMethod -Uri $uri -Method POST -Headers $headers -ContentType "application/json" -Body $jsonBody
+                $result = Invoke-RestMethod -Uri $uri -Method POST -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
                 return $result
             }
             elseif (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -gt 1)) {
                 <# Bulk operation request #>
-                $result = Invoke-RestMethod -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body $jsonBody
+                $result = Invoke-RestMethod -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
                 return $result
             }
         }

--- a/Juriba.Platform/Public/New-JuribaImportLocation.ps1
+++ b/Juriba.Platform/Public/New-JuribaImportLocation.ps1
@@ -57,12 +57,12 @@ function New-JuribaImportLocation {
     
         try {
             if (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -eq 1)) {
-                $result = Invoke-RestMethod -Uri $uri -Method POST -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
+                $result = Invoke-RestMethod -Uri $uri -Method POST -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
                 return $result
             }
             elseif (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -gt 1)) {
                 <# Bulk operation request #>
-                $result = Invoke-RestMethod -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
+                $result = Invoke-RestMethod -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
                 return $result
             }
         }

--- a/Juriba.Platform/Public/New-JuribaImportUser.ps1
+++ b/Juriba.Platform/Public/New-JuribaImportUser.ps1
@@ -57,12 +57,12 @@ function New-JuribaImportUser {
     
         try {
             if (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -eq 1)) {
-                $result = Invoke-RestMethod -Uri $uri -Method POST -Headers $headers -ContentType "application/json" -Body $jsonBody
+                $result = Invoke-RestMethod -Uri $uri -Method POST -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
                 return $result
             }
             elseif (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -gt 1)) {
                 <# Bulk operation request #>
-                $result = Invoke-RestMethod -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body $jsonBody
+                $result = Invoke-RestMethod -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
                 return $result
             }
         }

--- a/Juriba.Platform/Public/New-JuribaImportUser.ps1
+++ b/Juriba.Platform/Public/New-JuribaImportUser.ps1
@@ -57,12 +57,12 @@ function New-JuribaImportUser {
     
         try {
             if (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -eq 1)) {
-                $result = Invoke-RestMethod -Uri $uri -Method POST -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
+                $result = Invoke-RestMethod -Uri $uri -Method POST -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
                 return $result
             }
             elseif (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -gt 1)) {
                 <# Bulk operation request #>
-                $result = Invoke-RestMethod -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
+                $result = Invoke-RestMethod -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
                 return $result
             }
         }

--- a/Juriba.Platform/Public/Set-JuribaImportApplication.ps1
+++ b/Juriba.Platform/Public/Set-JuribaImportApplication.ps1
@@ -64,12 +64,12 @@ function Set-JuribaImportApplication {
     
         try {
             if (($PSCmdlet.ShouldProcess($UniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -eq 1)) {
-                $result = Invoke-WebRequest -Uri $uri -Method PATCH -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
+                $result = Invoke-WebRequest -Uri $uri -Method PATCH -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
                 return $result
             }
             elseif ($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier) -and (($JsonBody | ConvertFrom-Json).Length -gt 1)) {
                 <# Bulk operation request #>
-                $result = Invoke-RestMethod -Uri $bulkuri -Method PATCH -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
+                $result = Invoke-RestMethod -Uri $bulkuri -Method PATCH -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
                 return $result
             }
         }

--- a/Juriba.Platform/Public/Set-JuribaImportApplication.ps1
+++ b/Juriba.Platform/Public/Set-JuribaImportApplication.ps1
@@ -64,12 +64,12 @@ function Set-JuribaImportApplication {
     
         try {
             if (($PSCmdlet.ShouldProcess($UniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -eq 1)) {
-                $result = Invoke-WebRequest -Uri $uri -Method PATCH -Headers $headers -ContentType "application/json" -Body $JsonBody
+                $result = Invoke-WebRequest -Uri $uri -Method PATCH -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
                 return $result
             }
             elseif ($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier) -and (($JsonBody | ConvertFrom-Json).Length -gt 1)) {
                 <# Bulk operation request #>
-                $result = Invoke-RestMethod -Uri $bulkuri -Method PATCH -Headers $headers -ContentType "application/json" -Body $jsonBody
+                $result = Invoke-RestMethod -Uri $bulkuri -Method PATCH -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
                 return $result
             }
         }

--- a/Juriba.Platform/Public/Set-JuribaImportDepartment.ps1
+++ b/Juriba.Platform/Public/Set-JuribaImportDepartment.ps1
@@ -64,12 +64,12 @@ function Set-JuribaImportDepartment {
     
         try {
             if (($PSCmdlet.ShouldProcess($UniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -eq 1)) {
-                $result = Invoke-WebRequest -Uri $uri -Method PATCH -Headers $headers -ContentType "application/json" -Body $JsonBody
+                $result = Invoke-WebRequest -Uri $uri -Method PATCH -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
                 return $result
             }
             elseif (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -gt 1)) {
                 <# Bulk operation request #>
-                $result = Invoke-RestMethod -Uri $bulkuri -Method PATCH -Headers $headers -ContentType "application/json" -Body $jsonBody
+                $result = Invoke-RestMethod -Uri $bulkuri -Method PATCH -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
                 return $result
             }
         }

--- a/Juriba.Platform/Public/Set-JuribaImportDepartment.ps1
+++ b/Juriba.Platform/Public/Set-JuribaImportDepartment.ps1
@@ -64,12 +64,12 @@ function Set-JuribaImportDepartment {
     
         try {
             if (($PSCmdlet.ShouldProcess($UniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -eq 1)) {
-                $result = Invoke-WebRequest -Uri $uri -Method PATCH -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
+                $result = Invoke-WebRequest -Uri $uri -Method PATCH -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
                 return $result
             }
             elseif (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -gt 1)) {
                 <# Bulk operation request #>
-                $result = Invoke-RestMethod -Uri $bulkuri -Method PATCH -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
+                $result = Invoke-RestMethod -Uri $bulkuri -Method PATCH -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
                 return $result
             }
         }

--- a/Juriba.Platform/Public/Set-JuribaImportDevice.ps1
+++ b/Juriba.Platform/Public/Set-JuribaImportDevice.ps1
@@ -64,12 +64,12 @@ function Set-JuribaImportDevice {
     
         try {
             if (($PSCmdlet.ShouldProcess($UniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -eq 1)) {
-                $result = Invoke-WebRequest -Uri $uri -Method PATCH -Headers $headers -ContentType "application/json" -Body $JsonBody
+                $result = Invoke-WebRequest -Uri $uri -Method PATCH -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
                 return $result
             }
             elseif (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -gt 1)) {
                 <# Bulk operation request #>
-                $result = Invoke-RestMethod -Uri $bulkuri -Method PATCH -Headers $headers -ContentType "application/json" -Body $jsonBody
+                $result = Invoke-RestMethod -Uri $bulkuri -Method PATCH -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
                 return $result
             }
         }

--- a/Juriba.Platform/Public/Set-JuribaImportDevice.ps1
+++ b/Juriba.Platform/Public/Set-JuribaImportDevice.ps1
@@ -64,12 +64,12 @@ function Set-JuribaImportDevice {
     
         try {
             if (($PSCmdlet.ShouldProcess($UniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -eq 1)) {
-                $result = Invoke-WebRequest -Uri $uri -Method PATCH -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
+                $result = Invoke-WebRequest -Uri $uri -Method PATCH -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
                 return $result
             }
             elseif (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -gt 1)) {
                 <# Bulk operation request #>
-                $result = Invoke-RestMethod -Uri $bulkuri -Method PATCH -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
+                $result = Invoke-RestMethod -Uri $bulkuri -Method PATCH -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
                 return $result
             }
         }

--- a/Juriba.Platform/Public/Set-JuribaImportGroup.ps1
+++ b/Juriba.Platform/Public/Set-JuribaImportGroup.ps1
@@ -63,12 +63,12 @@ function Set-JuribaImportGroup {
     
         try {
             if (($PSCmdlet.ShouldProcess($UniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -eq 1)) {
-                $result = Invoke-WebRequest -Uri $uri -Method PATCH -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
+                $result = Invoke-WebRequest -Uri $uri -Method PATCH -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
                 return $result
             }
             elseif (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -gt 1)) {
                 <# Bulk operation request #>
-                $result = Invoke-RestMethod -Uri $bulkuri -Method PATCH -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
+                $result = Invoke-RestMethod -Uri $bulkuri -Method PATCH -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
                 return $result
             }
         }

--- a/Juriba.Platform/Public/Set-JuribaImportGroup.ps1
+++ b/Juriba.Platform/Public/Set-JuribaImportGroup.ps1
@@ -63,12 +63,12 @@ function Set-JuribaImportGroup {
     
         try {
             if (($PSCmdlet.ShouldProcess($UniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -eq 1)) {
-                $result = Invoke-WebRequest -Uri $uri -Method PATCH -Headers $headers -ContentType "application/json" -Body $JsonBody
+                $result = Invoke-WebRequest -Uri $uri -Method PATCH -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
                 return $result
             }
             elseif (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -gt 1)) {
                 <# Bulk operation request #>
-                $result = Invoke-RestMethod -Uri $bulkuri -Method PATCH -Headers $headers -ContentType "application/json" -Body $jsonBody
+                $result = Invoke-RestMethod -Uri $bulkuri -Method PATCH -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
                 return $result
             }
         }

--- a/Juriba.Platform/Public/Set-JuribaImportLocation.ps1
+++ b/Juriba.Platform/Public/Set-JuribaImportLocation.ps1
@@ -64,12 +64,12 @@ function Set-JuribaImportLocation {
     
         try {
             if (($PSCmdlet.ShouldProcess($UniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -eq 1)) {
-                $result = Invoke-WebRequest -Uri $uri -Method PATCH -Headers $headers -ContentType "application/json" -Body $JsonBody
+                $result = Invoke-WebRequest -Uri $uri -Method PATCH -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
                 return $result
             }
             elseif (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -gt 1)) {
                 <# Bulk operation request #>
-                $result = Invoke-RestMethod -Uri $bulkuri -Method PATCH -Headers $headers -ContentType "application/json" -Body $jsonBody
+                $result = Invoke-RestMethod -Uri $bulkuri -Method PATCH -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
                 return $result
             }
         }

--- a/Juriba.Platform/Public/Set-JuribaImportLocation.ps1
+++ b/Juriba.Platform/Public/Set-JuribaImportLocation.ps1
@@ -64,12 +64,12 @@ function Set-JuribaImportLocation {
     
         try {
             if (($PSCmdlet.ShouldProcess($UniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -eq 1)) {
-                $result = Invoke-WebRequest -Uri $uri -Method PATCH -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
+                $result = Invoke-WebRequest -Uri $uri -Method PATCH -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
                 return $result
             }
             elseif (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -gt 1)) {
                 <# Bulk operation request #>
-                $result = Invoke-RestMethod -Uri $bulkuri -Method PATCH -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
+                $result = Invoke-RestMethod -Uri $bulkuri -Method PATCH -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
                 return $result
             }
         }

--- a/Juriba.Platform/Public/Set-JuribaImportUser.ps1
+++ b/Juriba.Platform/Public/Set-JuribaImportUser.ps1
@@ -64,12 +64,12 @@ function Set-JuribaImportUser {
     
         try {
             if (($PSCmdlet.ShouldProcess($UniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -eq 1)) {
-                $result = Invoke-WebRequest -Uri $uri -Method PATCH -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
+                $result = Invoke-WebRequest -Uri $uri -Method PATCH -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
                 return $result
             }
             elseif (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -gt 1)) {
                 <# Bulk operation request #>
-                $result = Invoke-RestMethod -Uri $bulkuri -Method PATCH -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
+                $result = Invoke-RestMethod -Uri $bulkuri -Method PATCH -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
                 return $result
             }
         }

--- a/Juriba.Platform/Public/Set-JuribaImportUser.ps1
+++ b/Juriba.Platform/Public/Set-JuribaImportUser.ps1
@@ -64,12 +64,12 @@ function Set-JuribaImportUser {
     
         try {
             if (($PSCmdlet.ShouldProcess($UniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -eq 1)) {
-                $result = Invoke-WebRequest -Uri $uri -Method PATCH -Headers $headers -ContentType "application/json" -Body $JsonBody
+                $result = Invoke-WebRequest -Uri $uri -Method PATCH -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
                 return $result
             }
             elseif (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -gt 1)) {
                 <# Bulk operation request #>
-                $result = Invoke-RestMethod -Uri $bulkuri -Method PATCH -Headers $headers -ContentType "application/json" -Body $jsonBody
+                $result = Invoke-RestMethod -Uri $bulkuri -Method PATCH -Headers $headers -ContentType "application/json" -Body [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
                 return $result
             }
         }


### PR DESCRIPTION
Updated all bulk wrapper functions to send a byte array rather than straight json to avoid rejection due to unicode chars in the data.


> We are allowing contributions for now with limited review whilst we learn what common practices, approach and recommendations we can follow prior to promoting these modules to our customers.

### Manual Tasks Checklist

- [ ] Increment module version number in /Juriba.Platform/Juriba.Platform.psd1
- [ ] Add new functions to 'FunctionsToExport' in /Juriba.Platform/Juriba.Platform.psd1
